### PR TITLE
PR-42: Release v1.0.7: fixed small errors and typos in repository

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -12,5 +12,5 @@ jobs:
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
         with:
-          file_or_dir: .github/workflows/**.yml
+          file_or_dir: .github/workflows/**.yaml
           config_data: "{extends: default, rules: {line-length: disable}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## v1.0.7 - 2024-01-08
 ### What's Changed
-**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.6...v1.0.7 by @obervinov in https://github.com/obervinov/_templates/pull/33
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.6...v1.0.7 by @obervinov in https://github.com/obervinov/_templates/pull/42
 #### 🐛 Bug Fixes
 * (Fix small errors and typos)[https://github.com/obervinov/_templates/issues/41]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.0.7 - 2024-01-08
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.6...v1.0.7 by @obervinov in https://github.com/obervinov/_templates/pull/33
+#### 🐛 Bug Fixes
+* (Fix small errors and typos)[https://github.com/obervinov/_templates/issues/41]
+
+
+
 ## v1.0.6 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.5...v1.0.6 by @obervinov in https://github.com/obervinov/_templates/pull/32

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _templates
-[![Release](https://github.com/obervinov/_templates/actions/workflows/.release.yml/badge.svg)](https://github.com/obervinov/_templates/actions/workflows/.release.yml)
-[![Tests and checks](https://github.com/obervinov/_templates/actions/workflows/.lint.yml/badge.svg)](https://github.com/obervinov/_templates/actions/workflows/.lint.yml)
+[![Release](https://github.com/obervinov/_templates/actions/workflows/.release.yaml/badge.svg)](https://github.com/obervinov/_templates/actions/workflows/.release.yaml)
+[![Tests and checks](https://github.com/obervinov/_templates/actions/workflows/.lint.yaml/badge.svg)](https://github.com/obervinov/_templates/actions/workflows/.lint.yaml)
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/obervinov/_templates?style=for-the-badge)
 ![GitHub last commit](https://img.shields.io/github/last-commit/obervinov/_templates?style=for-the-badge)


### PR DESCRIPTION
# PR-42: Release v1.0.7: fixed small errors and typos in repository
## v1.0.7 - 2024-01-08
### What's Changed
**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.6...v1.0.7 by @obervinov in https://github.com/obervinov/_templates/pull/33
#### 🐛 Bug Fixes
* (Fix small errors and typos)[https://github.com/obervinov/_templates/issues/41]
