### PR TITLE
PR-57: Add support for python 3.9 to matrix builds

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         poetry-version: ["1.7.1"]
 
     steps:

--- a/.github/workflows/pyproject.yaml
+++ b/.github/workflows/pyproject.yaml
@@ -42,7 +42,7 @@ jobs:
   verify-package-install-template:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         poetry-version: ["1.7.1"]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         poetry-version: ["1.7.1"]
     services:
       vault:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         poetry-version: ["1.7.1"]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.12...v1.0.13 by @obervinov in https://github.com/obervinov/_templates/pull/57
 #### 🐛 Bug Fixes
-* Add support in matrix for python 3.9
+* Add support for `python 3.9` to matrix builds
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,85 +15,81 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.11...v1.0.12 by @obervinov in https://github.com/obervinov/_templates/pull/47
 #### 🐛 Bug Fixes
-* (Fix PROJECT_DESCRIPTION variable in docker workflow #45)[https://github.com/obervinov/_templates/issues/45]
-* (Fix image reference `TAG` for Trivy job)[https://github.com/obervinov/_templates/issues/46]
+* [Fix PROJECT_DESCRIPTION variable in docker workflow #45](https://github.com/obervinov/_templates/issues/45)
+* [Fix image reference `TAG` for Trivy job](https://github.com/obervinov/_templates/issues/46)
 #### 🚀 Features
-* (Add support environment variables `PROJECT_NAME` and `PROJECT_VERSION` for docker build)[https://github.com/obervinov/_templates/issues/48]
+* [Add support environment variables `PROJECT_NAME` and `PROJECT_VERSION` for docker build](https://github.com/obervinov/_templates/issues/48)
 #### 💥 Breaking Changes
-* (Add poetry support for python repositories)[https://github.com/obervinov/_templates/issues/49]
+* [Add poetry support for python repositories](https://github.com/obervinov/_templates/issues/49)
 
 
 ## v1.0.11 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.10...v1.0.11 by @obervinov in https://github.com/obervinov/_templates/pull/37
 #### 🚀 Features
-* (Bump actions/checkout from 3 to 4 in /.github/workflows)[https://github.com/obervinov/_templates/pull/37]
+* [Bump actions/checkout from 3 to 4 in /.github/workflows](https://github.com/obervinov/_templates/pull/37)
 
 
 ## v1.0.10 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.9...v1.0.10 by @obervinov in https://github.com/obervinov/_templates/pull/38
 #### 🚀 Features
-* (Bump github/codeql-action from 2 to 3 in /.github/workflows)[https://github.com/obervinov/_templates/pull/38]
+* [Bump github/codeql-action from 2 to 3 in /.github/workflows](https://github.com/obervinov/_templates/pull/38)
 
 
 ## v1.0.9 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.8...v1.0.9 by @obervinov in https://github.com/obervinov/_templates/pull/39
 #### 🚀 Features
-* (Bump aquasecurity/trivy-action from 0.5.0 to 0.16.1 in /.github/workflows)[https://github.com/obervinov/_templates/pull/39]
+* [Bump aquasecurity/trivy-action from 0.5.0 to 0.16.1 in /.github/workflows](https://github.com/obervinov/_templates/pull/39)
 
 
 ## v1.0.8 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.7...v1.0.8 by @obervinov in https://github.com/obervinov/_templates/pull/40
 #### 🚀 Features
-* (Bump actions/setup-python from 3 to 5 in /.github/workflows)[https://github.com/obervinov/_templates/pull/40]
+* [Bump actions/setup-python from 3 to 5 in /.github/workflows](https://github.com/obervinov/_templates/pull/40)
 
 
 ## v1.0.7 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.6...v1.0.7 by @obervinov in https://github.com/obervinov/_templates/pull/42
 #### 🐛 Bug Fixes
-* (Fix small errors and typos)[https://github.com/obervinov/_templates/issues/41]
+* [Fix small errors and typos](https://github.com/obervinov/_templates/issues/41)
 
 
 ## v1.0.7 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.6...v1.0.7 by @obervinov in https://github.com/obervinov/_templates/pull/42
 #### 🐛 Bug Fixes
-* (Fix small errors and typos)[https://github.com/obervinov/_templates/issues/41]
+* [Fix small errors and typos](https://github.com/obervinov/_templates/issues/41)
 
 
 ## v1.0.6 - 2024-01-08
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.5...v1.0.6 by @obervinov in https://github.com/obervinov/_templates/pull/32
 #### 🐛 Bug Fixes
-* (Fix typos in templates)[https://github.com/obervinov/_templates/issues/27]
-* (Update the outdated save state in GitHub Actions)[https://github.com/obervinov/_templates/issues/34]
+* [Fix typos in templates](https://github.com/obervinov/_templates/issues/27)
+* [Update the outdated save state in GitHub Actions](https://github.com/obervinov/_templates/issues/34)
 #### 📚 Documentation
-* (Update repository map)[https://github.com/obervinov/_templates/issues/30]
+* [Update repository map](https://github.com/obervinov/_templates/issues/30)
 #### 💥 Breaking Changes
 * **Renamed all workflow files**
 #### 🚀 Features
-* (Add support EXTRA_ARGS and PROJECT_VERSION in docker build command)[https://github.com/obervinov/_templates/issues/26]
-* (Terraform-docs markdown for automatic creation and updating of documents)[https://github.com/obervinov/_templates/issues/29]
-* (Add workflow for helm charts repository)[https://github.com/obervinov/_templates/issues/31]
-* (Add Dependabot for GitHub Actions)[https://github.com/obervinov/_templates/issues/33]
+* [Add support EXTRA_ARGS and PROJECT_VERSION in docker build command](https://github.com/obervinov/_templates/issues/26)
+* [Terraform-docs markdown for automatic creation and updating of documents](https://github.com/obervinov/_templates/issues/29)
+* [Add workflow for helm charts repository](https://github.com/obervinov/_templates/issues/31)
+* [Add Dependabot for GitHub Actions](https://github.com/obervinov/_templates/issues/33)
 
 
 ## v1.0.5 - 2023-08-22
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.4...v1.0.5 by @obervinov in https://github.com/obervinov/_templates/pull/1
-#### 🐛 Bug Fixes
-None
 #### 📚 Documentation
-* (Added mega ico to templates)[https://github.com/obervinov/_templates/issues/22]
-#### 💥 Breaking Changes
-None
+* [Added mega ico to templates](https://github.com/obervinov/_templates/issues/22)
 #### 🚀 Features
-* (Changed ${{ github.sha }} to extract tag (or branch) from repository)[https://github.com/obervinov/_templates/issues/24]
-* (Added jobs for terraform modules)[https://github.com/obervinov/_templates/issues/21]
+* [Changed ${{ github.sha }} to extract tag (or branch) from repository](https://github.com/obervinov/_templates/issues/24)
+* [Added jobs for terraform modules](https://github.com/obervinov/_templates/issues/21)
 
 
 
@@ -101,11 +97,11 @@ None
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.3...v1.0.4 by @obervinov in https://github.com/obervinov/_templates/pull/10
 #### 🚀 Features
-* https://github.com/obervinov/_templates/issues/20
-* https://github.com/obervinov/_templates/issues/19
+* [Add dependencies: pytest-order and pytest-ordering](https://github.com/obervinov/_templates/issues/20)
+* [Add a workflow for pytest with a storage service dependency](https://github.com/obervinov/_templates/issues/19)
 #### 🐛 Bug Fixes
-* https://github.com/obervinov/_templates/issues/16
-* https://github.com/obervinov/_templates/issues/18
+* [Fix: typos in workflow obervinov/_templates/.github/workflows/verify.package.yml@v1.0.3](https://github.com/obervinov/_templates/issues/16)
+* [Fix: add the pylint module to install in the test.pylint.yml task](https://github.com/obervinov/_templates/issues/18)
 #### 💥 Breaking Changes
 * changed strategy.matrix `python-version: ["3.9", "3.10"]` -> `python-version: ["3.10"]` in all workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.0.13 - 2024-02-02
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.12...v1.0.13 by @obervinov in https://github.com/obervinov/_templates/pull/1
+#### 🐛 Bug Fixes
+* Add support in matrix for python 3.9
+
+
+
 ## v1.0.12 - 2024-01-19
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.11...v1.0.12 by @obervinov in https://github.com/obervinov/_templates/pull/47

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## v1.0.13 - 2024-02-02
 ### What's Changed
-**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.12...v1.0.13 by @obervinov in https://github.com/obervinov/_templates/pull/1
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.12...v1.0.13 by @obervinov in https://github.com/obervinov/_templates/pull/57
 #### 🐛 Bug Fixes
 * Add support in matrix for python 3.9
 

--- a/README.md
+++ b/README.md
@@ -23,26 +23,26 @@ This repository contains templates for creating standard repositories
 ## <img src="https://github.com/obervinov/_templates/blob/main/icons/stack.png" width="25" title="stack"> Repository map
 ```bash
 .
-├── .github
-│   ├── CODEOWNERS
-│   ├── ISSUE_TEMPLATE
-│   │   ├── bug_report.md
-│   │   ├── custom.md
-│   │   └── feature_request.md
-│   ├── pull_request_template.md
-│   └── workflows
-│       ├── .lint.yaml
-│       ├── .release.yaml
-│       ├── changelog.yaml
-│       ├── docker.yaml
-│       ├── helm.yaml
-│       ├── pylint.yaml
-│       ├── pypackage.yaml
-│       ├── pytest-with-vault.yaml
-│       ├── pytest.yaml
-│       ├── release.yaml
-│       ├── terraform.yaml
-│       └── yamllint.yaml
+.github/
+├── CODEOWNERS
+├── ISSUE_TEMPLATE
+│   ├── bug_report.md
+│   ├── custom.md
+│   └── feature_request.md
+├── dependabot.yml
+├── pull_request_template.md
+└── workflows
+    ├── changelog.yaml
+    ├── docker.yaml
+    ├── helm.yaml
+    ├── pylint.yaml
+    ├── pypackage.yaml
+    ├── pyproject.yaml
+    ├── pytest-with-vault.yaml
+    ├── pytest.yaml
+    ├── release.yaml
+    ├── terraform.yaml
+    └── yamllint.yaml
 ├── .gitignore
 ├── CHANGELOG.md
 ├── LICENSE


### PR DESCRIPTION
## v1.0.13 - 2024-02-02
### What's Changed
**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.0.12...v1.0.13 by @obervinov in https://github.com/obervinov/_templates/pull/57
#### 🐛 Bug Fixes
* Add support for `python 3.9` to matrix builds