### PR TITLE
Release v1.2.6: Bump dependency versions and add `PostgreSQL` support in pytest

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,7 +38,7 @@ jobs:
           docker build -t ghcr.io/${{ github.repository }}:${TAG} --build-arg="PROJECT_NAME=${{ github.event.repository.name }}" --build-arg="PROJECT_NAME=${PROJECT_NAME}" --build-arg="PROJECT_VERSION=${TAG}" --build-arg="PROJECT_DESCRIPTION=${PROJECT_DESCRIPTION}" .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           image-ref: 'ghcr.io/${{ github.repository }}:${{ env.TAG }}'
           format: 'template'

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -20,6 +20,14 @@ jobs:
           VAULT_API_ADDR: http://0.0.0.0:8200
         options: >-
           --cap-add=IPC_LOCK
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.2.6 - 2024-06-09
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.5...v1.2.6 by @obervinov in https://github.com/obervinov/_templates/pull/84
+#### 🚀 Features
+* [Add support for `PostgreSQL` in the pytest workflow](https://github.com/obervinov/_templates/pull/84)
+* [Bump trivy-action to `0.22.0` in the docker workflow](https://github.com/obervinov/_templates/pull/78)
+
+
 ## v1.2.5 - 2024-05-29
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.4...v1.2.5 by @obervinov in https://github.com/obervinov/_templates/pull/82


### PR DESCRIPTION
## v1.2.6 - 2024-06-09
### What's Changed
**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.5...v1.2.6 by @obervinov in https://github.com/obervinov/_templates/pull/84
#### 🚀 Features
* https://github.com/obervinov/_templates/pull/84
* https://github.com/obervinov/_templates/pull/78


