### PR TITLE
Fix v1.2.7: Small fixes and improvements for `docker` and `images` workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,7 +38,7 @@ jobs:
           docker build -t ghcr.io/${{ github.repository }}:${TAG} --build-arg="PROJECT_NAME=${{ github.event.repository.name }}" --build-arg="PROJECT_NAME=${PROJECT_NAME}" --build-arg="PROJECT_VERSION=${TAG}" --build-arg="PROJECT_DESCRIPTION=${PROJECT_DESCRIPTION}" .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.22.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: 'ghcr.io/${{ github.repository }}:${{ env.TAG }}'
           format: 'template'
@@ -56,3 +56,5 @@ jobs:
           # Push image to ghcr
           echo ${{ github.token }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker push ghcr.io/${{ github.repository_owner }}/${GITHUB_REPOSITORY#${{ github.repository_owner }}/}:$TAG
+          docker tag ghcr.io/${{ github.repository_owner }}/${GITHUB_REPOSITORY#${{ github.repository_owner }}/}:$TAG ghcr.io/${{ github.repository_owner }}/${GITHUB_REPOSITORY#${{ github.repository_owner }}/}:latest
+          docker push ghcr.io/${{ github.repository_owner }}/${GITHUB_REPOSITORY#${{ github.repository_owner }}/}:latest

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -29,9 +29,11 @@ jobs:
           echo ${{ github.token }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           for dockerfile in ${{ steps.find_dockerfiles.outputs.list }}; do
             image_name=$(echo $dockerfile | awk -F '/' '{print $3}')
-            image_tag=$(cat $dockerfile | grep -i 'LABEL org.opencontainers.image.version'| awk '{print $3}')
+            image_tag=$(cat $dockerfile | grep -i 'ARG IMAGE_VERSION='| awk -F = '{print $2}')
             docker build -t ghcr.io/${{ github.repository }}/${image_name}:${image_tag} --build-arg="PROJECT_NAME=${{ github.event.repository.name }}" $(dirname $dockerfile) --quiet
             docker push ghcr.io/${{ github.repository }}/${image_name}:${image_tag}
+            docker tag ghcr.io/${{ github.repository }}/${image_name}:${image_tag} ghcr.io/${{ github.repository }}/${image_name}:latest
+            docker push ghcr.io/${{ github.repository }}/${image_name}:latest
           done
 
       - name: Install Trivy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.2.7 - 2024-08-12
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.6...v1.2.7 by @obervinov in https://github.com/obervinov/_templates/pull/84
+#### 🚀 Features
+* Bump trivy-action to `0.24.0` in the docker workflow
+* [Feature request: Docker workflow: auto create `latest` tag in PR](https://github.com/obervinov/_templates/issues/83)
+* Change the new image version detection selector from `LABEL org.opencontainers.image.version` to `ARG IMAGE_VERSION=` in `images` workflow  
+#### 💥 Breaking Changes
+* Change the new image version detection selector from `LABEL org.opencontainers.image.version` to `ARG IMAGE_VERSION=` in `images` workflow
+
+
 ## v1.2.6 - 2024-06-09
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.5...v1.2.6 by @obervinov in https://github.com/obervinov/_templates/pull/84


### PR DESCRIPTION
## v1.2.7 - 2024-08-12
### What's Changed
**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.6...v1.2.7 by @obervinov in https://github.com/obervinov/_templates/pull/84
#### 🚀 Features
* Bump trivy-action to `0.24.0` in the docker workflow
* https://github.com/obervinov/_templates/issues/83
* Change the new image version detection selector from `LABEL org.opencontainers.image.version` to `ARG IMAGE_VERSION=` in `images` workflow  
#### 💥 Breaking Changes
* Change the new image version detection selector from `LABEL org.opencontainers.image.version` to `ARG IMAGE_VERSION=` in `images` workflow


