### PR TITLE
Fix v1.2.9: Remove the matrix strategy from the workflows and bump dependencies version

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-        poetry-version: ["1.7.1"]
+        # Matrix builds can conflict with the Github Actions Services (because services is single-run)
+        python-version: ["3.10"]
+        poetry-version: ["1.8.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pyproject.yaml
+++ b/.github/workflows/pyproject.yaml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         # Matrix builds can conflict with the Github Actions Services (because services is single-run)
         python-version: ["3.10"]
-        poetry-version: ["1.7.1"]
+        poetry-version: ["1.8.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pyproject.yaml
+++ b/.github/workflows/pyproject.yaml
@@ -42,7 +42,8 @@ jobs:
   verify-package-install-template:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        # Matrix builds can conflict with the Github Actions Services (because services is single-run)
+        python-version: ["3.10"]
         poetry-version: ["1.7.1"]
     runs-on: ubuntu-latest
     steps:
@@ -64,8 +65,9 @@ jobs:
   build-poetry-dependencies-template:
     strategy:
       matrix:
-        python-version: ["3.10"]  # minimul supported version
-        poetry-version: ["1.7.1"]
+        # Matrix builds can conflict with the Github Actions Services (because services is single-run)
+        python-version: ["3.10"]
+        poetry-version: ["1.8.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -19,6 +19,7 @@ jobs:
         env:
           VAULT_LOCAL_CONFIG: '{"backend": {"file": {"path": "/vault/data"}}, "default_lease_ttl": "1h", "max_lease_ttl": "720h", "listener": {"tcp": {"address": "0.0.0.0:8200", "tls_disable": "1"}}'
           VAULT_API_ADDR: http://0.0.0.0:8200
+          VAULT_LOG_LEVEL: DEBUG
         options: >-
           --cap-add=IPC_LOCK
       postgres:
@@ -27,6 +28,11 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -28,11 +28,6 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
-        options: >-
-          --health-cmd pg_isready --username=postgres
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -8,11 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-        poetry-version: ["1.7.1"]
+        # Matrix builds can conflict with the Github Actions Services (because services is single-run)
+        python-version: ["3.10"]
+        poetry-version: ["1.8.3"]
     services:
       vault:
-        image: ghcr.io/obervinov/images/vault:1.13.2
+        image: ghcr.io/obervinov/images/vault:1.17.2
         ports:
           - 8200:8200
         env:

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -29,7 +29,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         options: >-
-          --health-cmd pg_isready
+          --health-cmd pg_isready -U postgres
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/pytest-with-vault.yaml
+++ b/.github/workflows/pytest-with-vault.yaml
@@ -29,7 +29,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         options: >-
-          --health-cmd pg_isready -U postgres
+          --health-cmd pg_isready --username=postgres
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-        poetry-version: ["1.7.1"]
+        python-version: ["3.10"]
+        poetry-version: ["1.8.3"]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 #### 🚀 Features
 * Bump poetry version to `1.8.3` in the python workflow
 * Bump vault-server image version to `1.17.2` in the python workflows
+* Add debug log level for the vault services in the python workflows
+* Add health check for the postgres service in the python workflows
 
 
 ## v1.2.8 - 2024-08-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.2.9 - 2024-09-03
+## v1.2.9 - 2024-09-05
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.8...v1.2.9 by @obervinov in https://github.com/obervinov/_templates/pull/90
 #### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 * Bump poetry version to `1.8.3` in the python workflow
 * Bump vault-server image version to `1.17.2` in the python workflows
 * Add debug log level for the vault services in the python workflows
-* Add health check for the postgres service in the python workflows
 
 
 ## v1.2.8 - 2024-08-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.2.9 - 2024-09-02
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.8...v1.2.9 by @obervinov in https://github.com/obervinov/_templates/pull/90
+#### 🐛 Bug Fixes
+* Remove the matrix strategy from the python workflow
+#### 💥 Breaking Changes
+* Remove the matrix strategy from the python workflow (because it's causing conflicts with the github actions services)
+* Let's use only one version of python in the python workflow (`3.10`)
+#### 🚀 Features
+* Bump poetry version to `1.8.3` in the python workflow
+* Bump vault-server image version to `1.17.2` in the python workflows
+
+
 ## v1.2.8 - 2024-08-14
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.7...v1.2.8 by @obervinov in https://github.com/obervinov/_templates/pull/85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.2.9 - 2024-09-02
+## v1.2.9 - 2024-09-03
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.8...v1.2.9 by @obervinov in https://github.com/obervinov/_templates/pull/90
 #### 🐛 Bug Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,5 @@ Versions supported to fix vulnerabilities
 
 ## Reporting a Vulnerability
 
-In order to inform me about the vulnerability, write the details to the mail `github.obervinov@proton.me`
+In order to inform me about the vulnerability, just create an issue: https://github.com/obervinov/_templates/security/advisories/new
+```


### PR DESCRIPTION
## v1.2.9 - 2024-09-05
### What's Changed
**Full Changelog**: https://github.com/obervinov/_templates/compare/v1.2.8...v1.2.9 by @obervinov in https://github.com/obervinov/_templates/pull/90
#### 🐛 Bug Fixes
* Remove the matrix strategy from the python workflow
#### 💥 Breaking Changes
* Remove the matrix strategy from the python workflow (because it's causing conflicts with the github actions services)
* Let's use only one version of python in the python workflow (`3.10`)
#### 🚀 Features
* Bump poetry version to `1.8.3` in the python workflow
* Bump vault-server image version to `1.17.2` in the python workflows
* Add debug log level for the vault services in the python workflows
