### PR TITLE
Add golang.yaml reusable CI workflow (v2.2.0)

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -1,0 +1,38 @@
+---
+name: Golang CI template
+
+on: [workflow_call]  # yamllint disable-line rule:truthy
+
+jobs:
+  golang-ci-template:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Check formatting with gofmt
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt-formatted, run 'gofmt -w .':"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Analysing the code with go vet
+        run: go vet ./...
+
+      - name: Analysing the code with golangci-lint
+        uses: golangci/golangci-lint-action@v6
+
+      - name: Testing with go test
+        run: go test ./... -race -cover
+
+      - name: Building
+        run: go build ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v2.2.0 - 2026-07-02
+### What's Changed
+#### 🚀 Features
+* Add `golang.yaml` reusable workflow: gofmt, go vet, golangci-lint, `go test -race -cover` and build for Go projects.
+
 ## v2.1.1 - 2025-01-29
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/_templates/compare/v2.1.0...v2.1.1 by @obervinov in https://github.com/obervinov/_templates/pull/104


### PR DESCRIPTION
## v2.2.0 - 2026-07-02
### What's Changed
#### 🚀 Features
* Add `golang.yaml` reusable workflow: gofmt, go vet, golangci-lint, `go test -race -cover` and build for Go projects.

