### PR TITLE
Fix golang.yaml linting for Go 1.25 modules (v2.2.1)

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Analysing the code with golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.12.2
 
       - name: Testing with go test
         run: go test ./... -race -cover

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -29,7 +29,9 @@ jobs:
         run: go vet ./...
 
       - name: Analysing the code with golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
 
       - name: Testing with go test
         run: go test ./... -race -cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v2.2.1 - 2026-07-04
+## v2.2.1 - 2026-07-30
 ### What's Changed
 #### 🐛 Bug Fixes
-* Bump `golang.yaml` to golangci-lint-action v8 (`version: latest`) so linting works against Go 1.25 modules.
+* Bump `golang.yaml` to `golangci-lint-action@v8` with `version: latest`. The v6 action pinned a golangci-lint binary built with an older Go that refuses to lint Go 1.25 modules (`the Go language version used to build golangci-lint is lower than the targeted Go version`); the latest binary is built with a current Go and lints them correctly.
 
 ## v2.2.0 - 2026-07-02
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v2.2.1 - 2026-07-04
+### What's Changed
+#### 🐛 Bug Fixes
+* Bump `golang.yaml` to golangci-lint-action v8 (`version: latest`) so linting works against Go 1.25 modules.
+
 ## v2.2.0 - 2026-07-02
 ### What's Changed
 #### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## v2.2.1 - 2026-07-30
 ### What's Changed
 #### 🐛 Bug Fixes
-* Bump `golang.yaml` to `golangci-lint-action@v8` with `version: latest`. The v6 action pinned a golangci-lint binary built with an older Go that refuses to lint Go 1.25 modules (`the Go language version used to build golangci-lint is lower than the targeted Go version`); the latest binary is built with a current Go and lints them correctly.
+* Bump `golang.yaml` to `golangci-lint-action@v8` pinned to golangci-lint `v2.12.2`. The v6 action pinned an older golangci-lint built with an older Go that refuses to lint Go 1.25 modules (`the Go language version used to build golangci-lint is lower than the targeted Go version`); v2.12.2 is built with a current Go and lints them correctly.
 
 ## v2.2.0 - 2026-07-02
 ### What's Changed


### PR DESCRIPTION
## v2.2.1 - 2026-07-30
### What's Changed
#### 🐛 Bug Fixes
* Bump `golang.yaml` to `golangci-lint-action@v8` pinned to golangci-lint `v2.12.2`. The v6 action pinned an older golangci-lint built with an older Go that refuses to lint Go 1.25 modules `the Go language version used to build golangci-lint is lower than the targeted Go version`; v2.12.2 is built with a current Go and lints them correctly.

