### PR TITLE
Bump GitHub Actions to address Dependabot alerts (v2.2.2)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU (for Docker buildx)
         uses: docker/setup-qemu-action@v3
@@ -71,7 +71,7 @@ jobs:
           docker run --rm --platform linux/arm64 ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }} uname -m
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}'
           format: 'template'
@@ -81,7 +81,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
         continue-on-error: true

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install helm and dependencies
         run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU (for Docker buildx)
         uses: docker/setup-qemu-action@v3
@@ -69,6 +69,6 @@ jobs:
           done
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'results/'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ jobs:
   pull-request-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version in CHANGELOG.md
         run: echo "version=$(grep -E '## v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' CHANGELOG.md | head -1 | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?')" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
           release_body=$(sed -n "/## $release_version /,/## v/p" CHANGELOG.md | sed '$ d' | sed 's/\[.*\]//g' | sed 's/[(|)]//g' | perl -pe 's/\n/\\n/g')
           printf "Release body:\n%s\n" "$release_body"
           # Create new PR
-          new_version=$(echo ${{ github.ref }} | sed 's/refs\/heads\///'| sed 's/\// /g'")
+          new_version=$(echo ${{ github.ref }} | sed 's/refs\/heads\///'| sed 's/\// /g')
           pr_title="Release $new_version"
           curl -q -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" -X POST -d "{\"title\": \"$pr_title\", \"head\": \"${{ github.ref }}\", \"base\": \"main\", \"body\": \"$release_body\"}" https://api.github.com/repos/${{ github.repository_owner}}/${{ github.event.repository.name }}/pulls
           printf "Created PR with number: %s\n" "$pr"

--- a/.github/workflows/pyproject.yaml
+++ b/.github/workflows/pyproject.yaml
@@ -34,10 +34,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
   release-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version in CHANGELOG.md
         run: echo "version=$(grep -E '## v[0-9]?([0-9]).[0-9]?([0-9]).[0-9]?([0-9])' CHANGELOG.md | head -1 | grep -Eo 'v[0-9]?([0-9]).[0-9]?([0-9]).[0-9]?([0-9])')" >> $GITHUB_OUTPUT

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -7,7 +7,7 @@ jobs:
   test-yamllint-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 * Bump `aquasecurity/trivy-action` to `0.36.0`, fixing the critical supply-chain advisory affecting versions `< 0.35.0`.
 #### ⬆️ Dependencies
 * Bump `actions/checkout` to `v6`, `actions/setup-python` to `v6`, and `github/codeql-action` to `v4`.
+#### 🐛 Bug Fixes
+* Fix a stray double quote in `pr.yaml`'s "create pull request" step that broke the shell (`unexpected EOF`) when the branch had no PR yet.
 
 ## v2.2.1 - 2026-07-30
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v2.2.2 - 2026-07-30
+### What's Changed
+#### 🔒 Security
+* Bump `aquasecurity/trivy-action` to `0.36.0`, fixing the critical supply-chain advisory affecting versions `< 0.35.0`.
+#### ⬆️ Dependencies
+* Bump `actions/checkout` to `v6`, `actions/setup-python` to `v6`, and `github/codeql-action` to `v4`.
+
 ## v2.2.1 - 2026-07-30
 ### What's Changed
 #### 🐛 Bug Fixes


### PR DESCRIPTION
Consolidates the open Dependabot bumps into one PR with a CHANGELOG entry so it passes the version/date gate and merges cleanly.

- **Security (critical):** `aquasecurity/trivy-action` `0.29.0` → `0.36.0` — fixes the supply-chain advisory affecting `< 0.35.0` (Dependabot #114 only reached `0.34.0`, still vulnerable).
- `actions/checkout` `v4` → `v6`
- `actions/setup-python` `v5` → `v6`
- `github/codeql-action/upload-sarif` `v3` → `v4`

Supersedes #110, #112, #113, #114 — those can be closed.